### PR TITLE
debuggerd: Rebrand tombstone header to LineageOS

### DIFF
--- a/debuggerd/tombstone.cpp
+++ b/debuggerd/tombstone.cpp
@@ -173,7 +173,7 @@ static void dump_header_info(log_t* log) {
   property_get("ro.build.fingerprint", fingerprint, "unknown");
   property_get("ro.revision", revision, "unknown");
 
-  _LOG(log, logtype::HEADER, "CM Version: '%s'\n", cm_version);
+  _LOG(log, logtype::HEADER, "LineageOS Version: '%s'\n", cm_version);
   _LOG(log, logtype::HEADER, "Build fingerprint: '%s'\n", fingerprint);
   _LOG(log, logtype::HEADER, "Revision: '%s'\n", revision);
   _LOG(log, logtype::HEADER, "ABI: '%s'\n", ABI_STRING);


### PR DESCRIPTION
Change-Id: Idd08c2eb7e395b464b1510742bf52833f465db08
(cherry picked from commit 4a427dfce617e1c3cc8b85b7196be24b495d9f4e)