### PR TITLE
Fix out of bound read in libziparchive

### DIFF
--- a/libziparchive/zip_archive.cc
+++ b/libziparchive/zip_archive.cc
@@ -580,15 +580,18 @@ static int32_t ParseZipArchive(ZipArchive* archive) {
   const uint8_t* const cd_end = cd_ptr + cd_length;
   const uint8_t* ptr = cd_ptr;
   for (uint16_t i = 0; i < num_entries; i++) {
+    if (ptr > cd_end - sizeof(CentralDirectoryRecord)) {
+      ALOGW("Zip: ran off the end (at %" PRIu16 ")", i);
+#if defined(__ANDROID__)
+      android_errorWriteLog(0x534e4554, "36392138");
+#endif
+      return -1;
+    }
+
     const CentralDirectoryRecord* cdr =
         reinterpret_cast<const CentralDirectoryRecord*>(ptr);
     if (cdr->record_signature != CentralDirectoryRecord::kSignature) {
       ALOGW("Zip: missed a central dir sig (at %" PRIu16 ")", i);
-      return -1;
-    }
-
-    if (ptr + sizeof(CentralDirectoryRecord) > cd_end) {
-      ALOGW("Zip: ran off the end (at %" PRIu16 ")", i);
       return -1;
     }
 


### PR DESCRIPTION
We should check the boundary of central directory before checking its
signature. Swap the order of these two checks.

Bug: 36392138
Test: libziparchive doesn't read the signature after boundary check fails.
AOSP-Change-Id: Ie89f709bb2d1ccb647116fb7ccb1e23c943e5ab8
(cherry picked from commit 74464a1361562d4042a67c5d66bfcf396ee7e59c)
(cherry picked from commit d9fd1863f46d5185eaaebc0803ee9c5da3ef110b)

CVE-2017-0647

Change-Id: I85baf2536b682cd91fb13b530af76dc15dd48326